### PR TITLE
Add Typer CLI skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # chatops
+
 Chat for Operations teams
+
+## CLI Usage
+
+The CLI is built with [Typer](https://typer.tiangolo.com/). After installing the dependencies you can run the application with:
+
+```bash
+python -m chatops
+```
+
+### Folder Structure
+
+```
+chatops/
+├── chatops/            # Python package
+│   ├── __init__.py
+│   ├── __main__.py
+│   ├── cli.py
+│   ├── cost.py
+│   ├── deploy.py
+│   ├── incident.py
+│   ├── logs.py
+│   └── security.py
+└── README.md
+```

--- a/chatops/__init__.py
+++ b/chatops/__init__.py
@@ -1,0 +1,5 @@
+"""ChatOps command line application."""
+
+from .cli import app
+
+__all__ = ["app"]

--- a/chatops/__main__.py
+++ b/chatops/__main__.py
@@ -1,0 +1,4 @@
+from .cli import app
+
+if __name__ == "__main__":
+    app()

--- a/chatops/cli.py
+++ b/chatops/cli.py
@@ -1,0 +1,11 @@
+import typer
+
+from . import deploy, logs, cost, incident, security
+
+app = typer.Typer(help="ChatOps CLI")
+
+app.add_typer(deploy.app, name="deploy")
+app.add_typer(logs.app, name="logs")
+app.add_typer(cost.app, name="cost")
+app.add_typer(incident.app, name="incident")
+app.add_typer(security.app, name="security")

--- a/chatops/cost.py
+++ b/chatops/cost.py
@@ -1,0 +1,8 @@
+import typer
+
+app = typer.Typer(help="Cost management commands")
+
+@app.command()
+def report():
+    """Generate cost report."""
+    typer.echo("Cost report for the month")

--- a/chatops/deploy.py
+++ b/chatops/deploy.py
@@ -1,0 +1,8 @@
+import typer
+
+app = typer.Typer(help="Deployment related commands")
+
+@app.command()
+def status():
+    """Show deployment status."""
+    typer.echo("Deployment is healthy")

--- a/chatops/incident.py
+++ b/chatops/incident.py
@@ -1,0 +1,8 @@
+import typer
+
+app = typer.Typer(help="Incident management commands")
+
+@app.command()
+def list():
+    """List current incidents."""
+    typer.echo("No active incidents")

--- a/chatops/logs.py
+++ b/chatops/logs.py
@@ -1,0 +1,8 @@
+import typer
+
+app = typer.Typer(help="Logging related commands")
+
+@app.command()
+def show(tail: int = 10):
+    """Show recent logs."""
+    typer.echo(f"Showing last {tail} log entries")

--- a/chatops/security.py
+++ b/chatops/security.py
@@ -1,0 +1,8 @@
+import typer
+
+app = typer.Typer(help="Security related commands")
+
+@app.command()
+def scan():
+    """Run security scan."""
+    typer.echo("Security scan completed")


### PR DESCRIPTION
## Summary
- create a package for a Typer-based CLI named **chatops**
- implement the main app and five subcommand modules
- document usage and folder structure

## Testing
- `python -m py_compile chatops/*.py`
- `python -m chatops --help`

------
https://chatgpt.com/codex/tasks/task_e_685487a29b088323b0fa70f099273506