### PR TITLE
Add AWS CloudWatch log command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ To rollback to the last successful deployment for an app and environment:
 python -m chatops deploy rollback APP ENV
 ```
 
+### Fetch AWS Logs
+
+Retrieve recent log events from AWS CloudWatch:
+
+```bash
+python -m chatops logs aws SERVICE --log-group LOG_GROUP --log-stream LOG_STREAM
+```
+
+If the log group or stream are not provided, the CLI will prompt for them interactively.
+
 ### Folder Structure
 
 ```

--- a/chatops/logs.py
+++ b/chatops/logs.py
@@ -1,3 +1,6 @@
+import boto3
+from rich.console import Console
+from rich.syntax import Syntax
 import typer
 
 app = typer.Typer(help="Logging related commands")
@@ -6,3 +9,32 @@ app = typer.Typer(help="Logging related commands")
 def show(tail: int = 10):
     """Show recent logs."""
     typer.echo(f"Showing last {tail} log entries")
+
+
+@app.command("aws")
+def aws_logs(
+    service: str = typer.Argument(..., help="Service identifier"),
+    log_group: str = typer.Option(None, "--log-group", "-g", help="CloudWatch log group"),
+    log_stream: str = typer.Option(
+        None, "--log-stream", "-s", help="CloudWatch log stream"
+    ),
+):
+    """Fetch the latest 50 log events from AWS CloudWatch Logs."""
+
+    if not log_group:
+        log_group = typer.prompt("Log group name")
+    if not log_stream:
+        log_stream = typer.prompt("Log stream name")
+
+    client = boto3.client("logs")
+    response = client.get_log_events(
+        logGroupName=log_group,
+        logStreamName=log_stream,
+        limit=50,
+        startFromHead=False,
+    )
+
+    console = Console()
+    console.print(f"[bold]Service:[/] {service}")
+    for event in response.get("events", []):
+        console.print(Syntax(event.get("message", ""), "bash", theme="ansi_dark"))


### PR DESCRIPTION
## Summary
- add `/logs aws` command to fetch CloudWatch logs
- document how to use the new command

## Testing
- `python -m chatops logs show --tail 5`
- `AWS_DEFAULT_REGION=us-east-1 python -m chatops logs aws test --log-group dummy --log-stream dummy` *(fails: Unable to locate credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68548d767c2c8323a8572cce18a634ae