### PR TITLE
Add IAM check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ The CLI is built with [Typer](https://typer.tiangolo.com/). After installing the
 python -m chatops
 ```
 
+### IAM Checks
+
+To list IAM users and highlight those with admin-level permissions:
+
+```bash
+python -m chatops iam check
+```
+
 ### Rollback Deployments
 
 To rollback to the last successful deployment for an app and environment:
@@ -30,6 +38,7 @@ chatops/
 │   ├── deploy.py
 │   ├── incident.py
 │   ├── logs.py
+│   ├── iam.py
 │   └── security.py
 └── README.md
 ```

--- a/chatops/cli.py
+++ b/chatops/cli.py
@@ -1,6 +1,6 @@
 import typer
 
-from . import deploy, logs, cost, incident, security
+from . import deploy, logs, cost, incident, security, iam
 
 app = typer.Typer(help="ChatOps CLI")
 
@@ -9,3 +9,4 @@ app.add_typer(logs.app, name="logs")
 app.add_typer(cost.app, name="cost")
 app.add_typer(incident.app, name="incident")
 app.add_typer(security.app, name="security")
+app.add_typer(iam.app, name="iam")

--- a/chatops/iam.py
+++ b/chatops/iam.py
@@ -1,0 +1,85 @@
+from typing import Dict, Any
+
+import boto3
+from rich.console import Console
+from rich.table import Table
+import typer
+
+app = typer.Typer(help="IAM related commands")
+
+
+def _policy_allows_admin(policy: Dict[str, Any]) -> bool:
+    """Return True if the policy document grants full admin permissions."""
+    statements = policy.get("Statement", [])
+    if not isinstance(statements, list):
+        statements = [statements]
+    for stmt in statements:
+        if stmt.get("Effect") != "Allow":
+            continue
+        actions = stmt.get("Action")
+        resources = stmt.get("Resource")
+        if actions == "*" or actions == ["*"] or (isinstance(actions, list) and "*" in actions):
+            if resources == "*" or resources == ["*"] or (isinstance(resources, list) and "*" in resources):
+                return True
+    return False
+
+
+@app.command()
+def check():
+    """List IAM users and highlight those with admin-level permissions."""
+    iam = boto3.client("iam")
+    console = Console()
+    table = Table(title="IAM Users", show_header=True, header_style="bold magenta")
+    table.add_column("User", style="cyan")
+    table.add_column("Admin Access")
+
+    paginator = iam.get_paginator("list_users")
+    for page in paginator.paginate():
+        for user in page.get("Users", []):
+            user_name = user["UserName"]
+            is_admin = False
+
+            # Check attached user policies
+            aup = iam.list_attached_user_policies(UserName=user_name)
+            for policy in aup.get("AttachedPolicies", []):
+                if "AdministratorAccess" in policy.get("PolicyName", ""):
+                    is_admin = True
+                    break
+                pol = iam.get_policy(PolicyArn=policy["PolicyArn"])
+                version_id = pol["Policy"]["DefaultVersionId"]
+                version = iam.get_policy_version(PolicyArn=policy["PolicyArn"], VersionId=version_id)
+                doc = version["PolicyVersion"]["Document"]
+                if _policy_allows_admin(doc):
+                    is_admin = True
+                    break
+
+            if not is_admin:
+                # Inline user policies
+                for pname in iam.list_user_policies(UserName=user_name).get("PolicyNames", []):
+                    pol = iam.get_user_policy(UserName=user_name, PolicyName=pname)
+                    doc = pol.get("PolicyDocument", {})
+                    if _policy_allows_admin(doc):
+                        is_admin = True
+                        break
+
+            if not is_admin:
+                # Group policies
+                for grp in iam.list_groups_for_user(UserName=user_name).get("Groups", []):
+                    grp_name = grp["GroupName"]
+                    for policy in iam.list_attached_group_policies(GroupName=grp_name).get("AttachedPolicies", []):
+                        if "AdministratorAccess" in policy.get("PolicyName", ""):
+                            is_admin = True
+                            break
+                        pol = iam.get_policy(PolicyArn=policy["PolicyArn"])
+                        version_id = pol["Policy"]["DefaultVersionId"]
+                        version = iam.get_policy_version(PolicyArn=policy["PolicyArn"], VersionId=version_id)
+                        doc = version["PolicyVersion"]["Document"]
+                        if _policy_allows_admin(doc):
+                            is_admin = True
+                            break
+                    if is_admin:
+                        break
+            badge = "[red]⚠️ admin[/red]" if is_admin else ""
+            table.add_row(user_name, badge)
+
+    console.print(table)


### PR DESCRIPTION
## Summary
- add `/iam check` to list IAM users and detect admin access
- register the new iam command in the CLI
- document IAM usage and folder structure in README

## Testing
- `python -m chatops iam check --help`
- `python -m chatops iam check` *(fails: NoCredentialsError)*

------
https://chatgpt.com/codex/tasks/task_e_68548dd2fe7c832386ef20abbf83dd88