### PR TITLE
Add incident create command

### DIFF
--- a/chatops/incident.py
+++ b/chatops/incident.py
@@ -1,3 +1,5 @@
+import os
+import requests
 import typer
 
 app = typer.Typer(help="Incident management commands")
@@ -6,3 +8,26 @@ app = typer.Typer(help="Incident management commands")
 def list():
     """List current incidents."""
     typer.echo("No active incidents")
+
+
+@app.command()
+def create():
+    """Create a new incident using a dummy ITSM API."""
+    title = typer.prompt("Title")
+    severity = typer.prompt("Severity")
+    service = typer.prompt("Affected service")
+
+    api_url = os.environ.get("ITSM_API_URL", "https://httpbin.org/post")
+    body = {"title": title, "severity": severity, "service": service}
+
+    try:
+        resp = requests.post(api_url, json=body, timeout=5)
+    except requests.RequestException as exc:
+        typer.echo(f"Request failed: {exc}")
+        raise typer.Exit(code=1)
+
+    if resp.status_code in {200, 201, 202}:
+        typer.echo("Incident created")
+    else:
+        typer.echo(f"Failed to create incident: {resp.status_code} {resp.text}")
+        raise typer.Exit(code=1)


### PR DESCRIPTION
## Summary
- add a new `/incident create` command
- prompt for title, severity, and service and POST to a dummy API

## Testing
- `python -m chatops incident --help`
- `python -m chatops incident create <<'EOF'
Test incident
High
web-service
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68548dee265083239d0ff212ba94bae3