### PR TITLE
Add incident list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ To rollback to the last successful deployment for an app and environment:
 python -m chatops deploy rollback APP ENV
 ```
 
+### List Open Incidents
+
+To show currently open incidents:
+
+```bash
+python -m chatops incident list
+```
+
 ### Folder Structure
 
 ```

--- a/chatops/incident.py
+++ b/chatops/incident.py
@@ -1,8 +1,42 @@
+import os
+from datetime import datetime
+
+import requests
 import typer
 
 app = typer.Typer(help="Incident management commands")
 
 @app.command()
 def list():
-    """List current incidents."""
-    typer.echo("No active incidents")
+    """List open incidents with severity and time opened."""
+    base_url = os.environ.get("INCIDENT_API_URL")
+    token = os.environ.get("INCIDENT_API_TOKEN")
+    if not base_url or not token:
+        typer.echo("INCIDENT_API_URL and INCIDENT_API_TOKEN must be set")
+        raise typer.Exit(code=1)
+
+    url = f"{base_url.rstrip('/')}/incidents?status=open"
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    resp = requests.get(url, headers=headers)
+    if resp.status_code != 200:
+        typer.echo(f"Failed to fetch incidents: {resp.status_code} {resp.text}")
+        raise typer.Exit(code=1)
+
+    incidents = resp.json()
+    if not incidents:
+        typer.echo("No open incidents")
+        raise typer.Exit()
+
+    for incident in incidents:
+        severity = incident.get("severity", "unknown")
+        opened = incident.get("created_at") or incident.get("start_time")
+        if opened:
+            try:
+                dt = datetime.fromisoformat(opened.replace("Z", "+00:00"))
+                opened = dt.strftime("%Y-%m-%d %H:%M:%S")
+            except Exception:
+                pass
+        else:
+            opened = "unknown"
+
+        typer.echo(f"[{severity}] {opened}")


### PR DESCRIPTION
## Summary
- implement `/incident list` command to fetch incidents
- show severity and opened time
- document the new command in README

## Testing
- `python -m chatops incident list` *(fails: INCIDENT_API_URL and INCIDENT_API_TOKEN must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68548df9902c8323a061342734dde869