### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade build twine jq
+      - name: Build distribution
+        run: python -m build
+      - name: Obtain PyPI API token
+        id: mint-token
+        run: |
+          resp=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=pypi")
+          oidc_token=$(jq -r '.value' <<<"$resp")
+          resp=$(curl -X POST https://pypi.org/_/oidc/mint-token -d "{\"token\": \"${oidc_token}\"}")
+          api_token=$(jq -r '.token' <<<"$resp")
+          echo "::add-mask::${api_token}"
+          echo "token=${api_token}" >> "$GITHUB_OUTPUT"
+      - name: Publish package
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ steps.mint-token.outputs.token }}
+          TWINE_NON_INTERACTIVE: 1
+        run: twine upload dist/*


### PR DESCRIPTION
## Summary
- add a workflow that publishes releases to PyPI via trusted publishing

## Testing
- `pip install -e .`
- `pip install requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854932eed708323900eab1eebcc56c6