### PR TITLE
Enable manual publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - "v*.*.*"
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary
- allow manual execution of the publish workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549f0638c083239c8dd75a15d3c1c2