### PR TITLE
Fix CLI optional imports

### DIFF
--- a/chatops/cost.py
+++ b/chatops/cost.py
@@ -1,9 +1,10 @@
 from datetime import datetime, timedelta, timezone
 
-import boto3
 import typer
 from azure.identity import AzureCliCredential
 from azure.mgmt.costmanagement import CostManagementClient
+from rich.console import Console
+from rich.table import Table
 
 
 app = typer.Typer(help="Cost management commands")

--- a/chatops/incident.py
+++ b/chatops/incident.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 import requests
 import typer
 

--- a/chatops/logs.py
+++ b/chatops/logs.py
@@ -1,10 +1,7 @@
-import boto3
 from rich.console import Console
 from rich.syntax import Syntax
 import typer
-from azure.identity import AzureCliCredential
-from azure.monitor.query import LogsQueryClient
-from rich.console import Console
+
 from rich.table import Table
 
 app = typer.Typer(help="Logging related commands")
@@ -23,6 +20,12 @@ def aws_logs(
     ),
 ):
     """Fetch the latest 50 log events from AWS CloudWatch Logs."""
+
+    try:
+        import boto3  # type: ignore
+    except ImportError:
+        typer.echo("boto3 is required for this command")
+        raise typer.Exit(code=1)
 
     if not log_group:
         log_group = typer.prompt("Log group name")


### PR DESCRIPTION
## Summary
- make optional dependencies lazy imports in `logs`
- drop unused boto3 import in `cost`
- fix `incident` missing `datetime` import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855834f890c8323b2bb63209df56da3