### PR TITLE
Add support assistant REPL

### DIFF
--- a/chatops/cli.py
+++ b/chatops/cli.py
@@ -1,5 +1,5 @@
 import typer
-from . import deploy, logs, cost, iam, incident, security, cve, suggest, monitor, explain
+from . import deploy, logs, cost, iam, incident, security, cve, suggest, monitor, explain, support
 
 app = typer.Typer(help="ChatOps CLI")
 
@@ -13,3 +13,4 @@ app.add_typer(cve.app, name="cve")
 app.add_typer(suggest.app, name="suggest")
 app.add_typer(explain.app, name="explain")
 app.add_typer(monitor.app, name="monitor")
+app.add_typer(support.app, name="support")

--- a/chatops/support.py
+++ b/chatops/support.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import os
+import typer
+from rich.console import Console
+from rich.markdown import Markdown
+from .utils import log_command, time_command
+
+try:
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+
+app = typer.Typer(help="Interactive support assistant")
+
+
+def _client() -> 'openai.OpenAI':
+    if openai is None:
+        raise RuntimeError("openai package not installed")
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+    return openai.OpenAI(api_key=api_key)
+
+
+@time_command
+@log_command
+@app.command()
+def support():
+    """Launch an interactive DevOps assistant."""
+    console = Console()
+    try:
+        client = _client()
+    except Exception as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+    messages = [
+        {"role": "system", "content": "You are a helpful DevOps and cloud assistant"}
+    ]
+
+    while True:
+        try:
+            user_input = console.input("[bold blue]support> [/bold blue]")
+        except (EOFError, KeyboardInterrupt):
+            break
+        if user_input.strip().lower() in {"exit", "quit"}:
+            break
+        messages.append({"role": "user", "content": user_input})
+        try:
+            resp = client.chat.completions.create(
+                model="gpt-4",
+                messages=messages,
+                temperature=0.2,
+            )
+            reply = resp.choices[0].message.content
+            messages.append({"role": "assistant", "content": reply})
+            console.print(Markdown(reply))
+        except Exception as exc:
+            console.print(f"[red]Error: {exc}[/red]")
+    console.print("[green]Goodbye![/green]")


### PR DESCRIPTION
## Summary
- implement `support.py` providing a ChatGPT-powered REPL
- register new command in CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855da44cda08323bbbb7b7323b25472