### PR TITLE
Add chatops executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# chatops-toolkit
+# chatops
 
 A command line toolkit for operations teams built with [Typer](https://typer.tiangolo.com/).
 
@@ -10,12 +10,18 @@ Install from PyPI:
 pip install chatops
 ```
 
+For local development from a cloned repository:
+
+```bash
+pip install -e .
+```
+
 ## Usage
 
 Invoke the CLI with the installed entry point:
 
 ```bash
-chatops-toolkit --help
+chatops --help
 ```
 
 You can also run the package directly:
@@ -96,7 +102,7 @@ Both forms expose the same set of subcommands:
 Deploy an application (requires `GITHUB_TOKEN` and `GITHUB_REPOSITORY`):
 
 ```bash
-chatops-toolkit deploy deploy myapp prod
+chatops deploy deploy myapp prod
 ```
 
 Tail logs for a service:

--- a/bin/chatops
+++ b/bin/chatops
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+from chatops.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,5 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
+    chatops = chatops.cli:app
     chatops-toolkit = chatops.cli:app


### PR DESCRIPTION
## Summary
- make README show `chatops` entrypoint and `pip install -e .`
- expose a new `chatops` console script via setuptools
- add an executable wrapper script

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ef6d9514832381c2c6eebec76daa