### PR TITLE
Improve ChatOps CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Both forms expose the same set of subcommands:
 - `deploy rollback APP ENV` &ndash; rollback to last release
 
 #### logs
+- `logs SERVICE` &ndash; show recent log lines for a service
 - `logs live SERVICE` &ndash; stream live log lines
 - `logs grep PATTERN` &ndash; search log entries
 - `logs tail SERVICE [--lines N]` &ndash; tail logs (default 50 lines)
@@ -86,8 +87,8 @@ Both forms expose the same set of subcommands:
 - `cve search --keyword TEXT` &ndash; search CVEs
 
 #### suggest
-- `suggest suggest PROMPT` &ndash; suggest best CLI command
-- `suggest explain TEXT` &ndash; explain an error message
+- `suggest PROMPT` &ndash; suggest best CLI command
+- `explain TEXT` &ndash; explain an error message
 
 #### explain
 - `explain explain TEXT` &ndash; explain a stack trace
@@ -98,7 +99,7 @@ Both forms expose the same set of subcommands:
 - `monitor latency [--threshold MS]` &ndash; simulate latency alert
 
 #### support
-- `support support` &ndash; launch interactive assistant (prompts for `OPENAI_API_KEY` if needed)
+- `support` &ndash; launch interactive assistant (prompts for `OPENAI_API_KEY` if needed)
 
 ### Example commands
 
@@ -111,31 +112,31 @@ chatops deploy deploy myapp prod
 Tail logs for a service:
 
 ```bash
-python -m chatops logs tail myservice --lines 20
+chatops logs myservice
 ```
 
 Generate an Azure cost report for a subscription:
 
 ```bash
-python -m chatops cost azure --subscription-id <SUBSCRIPTION_ID>
+chatops cost azure --subscription-id <SUBSCRIPTION_ID>
 ```
 
 Show on-call rotation:
 
 ```bash
-python -m chatops incident who
+chatops incident who
 ```
 
 Run a security scan:
 
 ```bash
-python -m chatops security scan .
+chatops security scan .
 ```
 
 Display high or critical CVEs published in the last week:
 
 ```bash
-python -m chatops cve latest
+chatops cve latest
 ```
 
 ### Suggest a CLI Command

--- a/chatops/cli.py
+++ b/chatops/cli.py
@@ -10,7 +10,17 @@ app.add_typer(iam.app, name="iam")
 app.add_typer(incident.app, name="incident")
 app.add_typer(security.app, name="security")
 app.add_typer(cve.app, name="cve")
-app.add_typer(suggest.app, name="suggest")
 app.add_typer(explain.app, name="explain")
 app.add_typer(monitor.app, name="monitor")
-app.add_typer(support.app, name="support")
+
+
+@app.command("suggest")
+def suggest_cmd(prompt: str) -> None:
+    """Suggest best ChatOps command."""
+    suggest.suggest(prompt)
+
+
+@app.command("support")
+def support_cmd() -> None:
+    """Launch the interactive support assistant."""
+    support.support()

--- a/chatops/logs.py
+++ b/chatops/logs.py
@@ -6,7 +6,16 @@ from rich.table import Table
 from rich.live import Live
 from .utils import log_command, time_command
 
-app = typer.Typer(help="Logging related commands")
+app = typer.Typer(help="Logging related commands", invoke_without_command=True)
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context, service: str = typer.Argument(None, help="Service name")) -> None:
+    """Show logs for ``service`` when no subcommand is provided."""
+    if ctx.invoked_subcommand is None:
+        if not service:
+            raise typer.BadParameter("SERVICE is required")
+        tail(service)
 
 
 @time_command
@@ -46,3 +55,4 @@ def tail(service: str, lines: int = typer.Option(50, "--lines")):
     for i in range(lines):
         table.add_row(f"log line {i}")
     Console().print(table)
+

--- a/chatops/suggest.py
+++ b/chatops/suggest.py
@@ -74,13 +74,10 @@ import typer
 from rich.console import Console
 from .utils import log_command, time_command
 
-app = typer.Typer(help="AI powered helpers")
-
 
 @time_command
 @log_command
-@app.command()
-def suggest(prompt: str):
+def suggest(prompt: str) -> None:
     """Suggest best ChatOps command."""
     try:
         cmd = suggest_command(prompt)
@@ -92,8 +89,7 @@ def suggest(prompt: str):
 
 @time_command
 @log_command
-@app.command()
-def explain(text: str):
+def explain(text: str) -> None:
     """Use OpenAI to explain an error message."""
     try:
         client = _get_client()
@@ -102,3 +98,4 @@ def explain(text: str):
     except Exception as exc:
         Console().print(f"OpenAI error: {exc}")
         raise typer.Exit(1)
+

--- a/chatops/support.py
+++ b/chatops/support.py
@@ -10,9 +10,6 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     openai = None
 
-app = typer.Typer(help="Interactive support assistant")
-
-
 def _client(console: Console | None = None) -> 'openai.OpenAI':
     """Return an OpenAI client after ensuring an API key is available."""
     return openai_client(console)
@@ -20,8 +17,7 @@ def _client(console: Console | None = None) -> 'openai.OpenAI':
 
 @time_command
 @log_command
-@app.command()
-def support():
+def support() -> None:
     """Launch an interactive DevOps assistant."""
     console = Console()
     try:
@@ -54,3 +50,4 @@ def support():
         except Exception as exc:
             console.print(f"[red]Error: {exc}[/red]")
     console.print("[green]Goodbye![/green]")
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
 [build-system]
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "chatops"
+version = "0.3.0"
+description = "Command line toolkit for operations teams"
+authors = [{name = "Franck Kengne"}]
+
+[project.scripts]
+chatops = "chatops.cli:app"
+

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -2,6 +2,7 @@ import os
 from types import ModuleType
 from typer.testing import CliRunner
 import typer
+import os
 
 import chatops.support as support
 import chatops.openai_utils as openai_utils
@@ -72,7 +73,7 @@ def test_support_command(monkeypatch, tmp_path):
     monkeypatch.setattr(support, "Markdown", lambda x: x)
 
     runner = CliRunner()
-    result = runner.invoke(cli.app, ["support", "support"])
+    result = runner.invoke(cli.app, ["support"])
 
     assert result.exit_code == 0
     assert "Goodbye!" in output[-1]


### PR DESCRIPTION
## Summary
- add entry point configuration in `pyproject.toml`
- allow `logs` command to take a service argument
- move `support` to a single command
- expose `suggest` command directly from root
- update docs and tests for new command layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f48282a483239710d78115d48d2a