### PR TITLE
Add GCP provider and sandboxed environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,14 @@ environments:
     provider: local
   aws-prod:
     provider: aws
+  gcp-prod:
+    provider: gcp
 ```
 
-Activate one with ``chatops env use NAME``. Commands that interact with cloud
-providers read the active environment unless overridden with ``--env NAME``.
+Activate one with ``chatops env use NAME``. Each activation creates a sandbox
+directory under ``~/.chatops/sandboxes/NAME`` used by commands that interact
+with the chosen provider. Commands read the active environment unless
+overridden with ``--env NAME``.
 
 ### Command reference
 

--- a/chatops/config.py
+++ b/chatops/config.py
@@ -58,6 +58,6 @@ def validate_env(name: str) -> None:
     if env is None:
         raise ValueError(f"Environment {name} not found in config")
     provider = env.get("provider")
-    if provider not in {"azure", "aws", "docker", "local"}:
+    if provider not in {"azure", "aws", "gcp", "docker", "local"}:
         raise ValueError(f"Invalid provider for {name}")
 


### PR DESCRIPTION
## Summary
- support `gcp` provider in environment validation
- create per-environment sandbox directories on `env use`
- remove sandbox when environment exited
- document new provider and sandbox behaviour in README
- add tests for GCP support and sandbox creation

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856dec7cf908323b1a93dd1479fdd21