### PR TITLE
Add interactive cloud provider auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ overridden with ``--env NAME``.
 - `chatops env use NAME` &ndash; activate NAME
 - `chatops env current` &ndash; show the active environment
 - `chatops env list` &ndash; list configured environments
+- `chatops env status` &ndash; check auth for active environment
 - `chatops env exit` &ndash; deactivate the active environment
 
 #### generate

--- a/chatops/auth_cache.py
+++ b/chatops/auth_cache.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
+
+AUTH_CACHE_FILE = Path.home() / ".chatops" / ".auth_cache.yaml"
+
+
+def _load() -> Dict:
+    if not AUTH_CACHE_FILE.exists():
+        return {}
+    text = AUTH_CACHE_FILE.read_text()
+    if yaml is None:
+        # naive parse
+        data: Dict[str, bool] = {}
+        for line in text.splitlines():
+            if ":" in line:
+                k, v = line.split(":", 1)
+                data[k.strip()] = v.strip() == "true"
+        return data
+    try:
+        return yaml.safe_load(text) or {}
+    except Exception:
+        return {}
+
+
+def _save(data: Dict[str, bool]) -> None:
+    AUTH_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if yaml is None:
+        text = "\n".join(f"{k}: {'true' if v else 'false'}" for k, v in data.items())
+        AUTH_CACHE_FILE.write_text(text)
+    else:
+        AUTH_CACHE_FILE.write_text(yaml.safe_dump(data))
+
+
+def get(key: str) -> bool:
+    return _load().get(key, False)
+
+
+def set(key: str, value: bool) -> None:
+    data = _load()
+    data[key] = value
+    _save(data)

--- a/chatops/providers/aws.py
+++ b/chatops/providers/aws.py
@@ -1,10 +1,77 @@
 from __future__ import annotations
 from typing import Dict
+from pathlib import Path
+import configparser
 import os
+
+import typer
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError  # type: ignore
+except Exception:  # pragma: no cover - optional deps
+    boto3 = None  # type: ignore
+    ClientError = Exception  # type: ignore
+
+from .. import auth_cache
+
 
 def whoami(env: Dict) -> str:
     """Return a short identity string."""
     key = os.environ.get("AWS_ACCESS_KEY_ID")
     if key:
         return f"AWS access key: {key}"
+    profile = env.get("profile")
+    if profile:
+        return f"AWS profile: {profile}"
     return "AWS credentials not found"
+
+
+def _profile_name(env: Dict) -> str:
+    return env.get("profile") or env.get("name") or "default"
+
+
+def is_authenticated(env: Dict) -> bool:
+    if boto3 is None:
+        return False
+    profile = _profile_name(env)
+    if auth_cache.get(f"aws:{profile}"):
+        return True
+    try:
+        session = boto3.Session(profile_name=profile)
+        sts = session.client("sts")
+        sts.get_caller_identity()
+        auth_cache.set(f"aws:{profile}", True)
+        return True
+    except Exception:
+        return False
+
+
+def prompt_and_authenticate(env: Dict) -> None:
+    if boto3 is None:
+        raise RuntimeError("boto3 not available")
+    if is_authenticated(env):
+        return
+    profile = _profile_name(env)
+    typer.echo("AWS credentials not found. Enter access details:")
+    access_key = typer.prompt("Access key ID")
+    secret_key = typer.prompt("Secret access key", hide_input=True)
+    cfg_file = Path.home() / ".aws" / "credentials"
+    parser = configparser.RawConfigParser()
+    if cfg_file.exists():
+        parser.read(cfg_file)
+    if not parser.has_section(profile):
+        parser.add_section(profile)
+    parser.set(profile, "aws_access_key_id", access_key)
+    parser.set(profile, "aws_secret_access_key", secret_key)
+    cfg_file.parent.mkdir(parents=True, exist_ok=True)
+    with cfg_file.open("w") as fh:
+        parser.write(fh)
+    session = boto3.Session(
+        aws_access_key_id=access_key, aws_secret_access_key=secret_key
+    )
+    try:
+        session.client("sts").get_caller_identity()
+    except Exception as exc:
+        raise RuntimeError(f"AWS auth failed: {exc}")
+    auth_cache.set(f"aws:{profile}", True)

--- a/chatops/providers/azure.py
+++ b/chatops/providers/azure.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 from typing import Dict
 
+import typer
+
 try:
-    from azure.identity import AzureCliCredential  # type: ignore
+    from azure.identity import (
+        AzureCliCredential,
+        DeviceCodeCredential,
+        DefaultAzureCredential,
+    )  # type: ignore
     from azure.mgmt.subscription import SubscriptionClient  # type: ignore
 except Exception:  # pragma: no cover - optional deps
     AzureCliCredential = None  # type: ignore
+    DeviceCodeCredential = None  # type: ignore
+    DefaultAzureCredential = None  # type: ignore
     SubscriptionClient = None  # type: ignore
+
+from .. import auth_cache
 
 
 def whoami(env: Dict) -> str:
@@ -19,3 +29,32 @@ def whoami(env: Dict) -> str:
     tenant = next(sub_client.tenants.list())
     tid = str(getattr(tenant, "tenant_id", ""))
     return f"Azure tenant: {tid}"
+
+
+def is_authenticated(env: Dict) -> bool:
+    if DefaultAzureCredential is None:
+        return False
+    if auth_cache.get("azure"):
+        return True
+    try:
+        cred = DefaultAzureCredential(exclude_interactive_browser_credential=False)
+        cred.get_token("https://management.azure.com/.default")
+        auth_cache.set("azure", True)
+        return True
+    except Exception:
+        return False
+
+
+def prompt_and_authenticate(env: Dict) -> None:
+    if DefaultAzureCredential is None or DeviceCodeCredential is None:
+        raise RuntimeError("azure.identity not available")
+    if is_authenticated(env):
+        return
+    typer.echo("Opening browser to log in with device code...")
+    cred = DeviceCodeCredential(tenant_id=env.get("tenant_id"))
+    try:
+        cred.get_token("https://management.azure.com/.default")
+    except Exception as exc:
+        raise RuntimeError(f"Azure login failed: {exc}")
+    auth_cache.set("azure", True)
+

--- a/chatops/providers/docker.py
+++ b/chatops/providers/docker.py
@@ -1,9 +1,52 @@
 from __future__ import annotations
 from typing import Dict
+from pathlib import Path
 import os
+
+import typer
+
+try:
+    import docker  # type: ignore
+except Exception:  # pragma: no cover - optional deps
+    docker = None  # type: ignore
+
+from .. import auth_cache
 
 
 def whoami(env: Dict) -> str:
     """Return Docker host information."""
     socket = env.get("socket", "/var/run/docker.sock")
     return f"Docker socket: {os.path.basename(socket)}"
+
+
+def is_authenticated(env: Dict) -> bool:
+    if docker is None:
+        return False
+    if auth_cache.get("docker"):
+        return True
+    socket = env.get("socket", "/var/run/docker.sock")
+    url = f"unix://{socket}" if not socket.startswith("unix://") else socket
+    try:
+        client = docker.DockerClient(base_url=url)
+        client.ping()
+        auth_cache.set("docker", True)
+        return True
+    except Exception:
+        return False
+
+
+def prompt_and_authenticate(env: Dict) -> None:
+    if docker is None:
+        raise RuntimeError("docker SDK not available")
+    if is_authenticated(env):
+        return
+    typer.echo("Docker not accessible. Enter Docker host path:")
+    host = typer.prompt("Docker host", default=env.get("socket", "/var/run/docker.sock"))
+    env["socket"] = host
+    url = f"unix://{host}" if not host.startswith("unix://") else host
+    try:
+        docker.DockerClient(base_url=url).ping()
+    except Exception as exc:
+        raise RuntimeError(f"Docker auth failed: {exc}")
+    auth_cache.set("docker", True)
+

--- a/chatops/providers/gcp.py
+++ b/chatops/providers/gcp.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 from typing import Dict
+from pathlib import Path
+
+import typer
 
 try:
     from google.cloud import storage  # type: ignore
+    from google.oauth2 import service_account  # type: ignore
+    import google.auth  # type: ignore
 except Exception:  # pragma: no cover - optional deps
     storage = None  # type: ignore
+    service_account = None  # type: ignore
+    google = None  # type: ignore
+
+from .. import auth_cache
 
 
 def whoami(env: Dict) -> str:
@@ -14,3 +23,36 @@ def whoami(env: Dict) -> str:
         return f"GCP project: {pid}"
     client = storage.Client(project=env.get("project_id"))
     return f"GCP project: {client.project}"
+
+
+def is_authenticated(env: Dict) -> bool:
+    if google is None:
+        return False
+    proj = env.get("project_id", "default")
+    if auth_cache.get(f"gcp:{proj}"):
+        return True
+    try:
+        creds, project = google.auth.default()
+        if project:
+            auth_cache.set(f"gcp:{project}", True)
+            return True
+    except Exception:
+        return False
+    return False
+
+
+def prompt_and_authenticate(env: Dict) -> None:
+    if service_account is None:
+        raise RuntimeError("google-auth not available")
+    if is_authenticated(env):
+        return
+    path = typer.prompt("Enter path to service account JSON")
+    key_path = Path(path).expanduser()
+    try:
+        creds = service_account.Credentials.from_service_account_file(str(key_path))
+    except Exception as exc:
+        raise RuntimeError(f"GCP credential error: {exc}")
+    auth_cache.set(f"gcp:{creds.project_id}", True)
+    env["project_id"] = creds.project_id
+    env["service_account"] = str(key_path)
+

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -15,6 +15,8 @@ def test_env_use_and_current(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(env_mod, "ACTIVE_FILE", home / ".chatops" / ".active_env")
     monkeypatch.setattr(config, "CONFIG_FILE", cfg)
+    import chatops.providers.aws as aws_provider
+    monkeypatch.setattr(aws_provider, "prompt_and_authenticate", lambda env: None)
     runner.invoke(app, ["env", "use", "aws-test"], env={"HOME": str(home)})
     result = runner.invoke(app, ["env", "current"], env={"HOME": str(home)})
     assert "aws-test" in result.output
@@ -58,6 +60,8 @@ def test_env_use_creates_sandbox(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(env_mod, "ACTIVE_FILE", cfg / ".active_env")
     monkeypatch.setattr(env_mod, "SANDBOX_DIR", cfg / "sandboxes")
+    import chatops.providers.gcp as gcp_provider
+    monkeypatch.setattr(gcp_provider, "prompt_and_authenticate", lambda env: None)
     monkeypatch.setattr(config, "CONFIG_FILE", cfg_file)
     runner.invoke(app, ["env", "use", "gcp-test"], env={"HOME": str(home)})
     sandbox = cfg / "sandboxes" / "gcp-test"
@@ -65,3 +69,19 @@ def test_env_use_creates_sandbox(tmp_path, monkeypatch):
     assert (sandbox / "provider").read_text() == "gcp"
 
 
+
+def test_env_status(tmp_path, monkeypatch):
+    home = tmp_path
+    cfg = home / ".chatops"
+    cfg.mkdir()
+    cfg_file = cfg / "config.yaml"
+    cfg_file.write_text(
+        "environments:\n  aws-prod:\n    provider: aws\n"
+    )
+    monkeypatch.setattr(env_mod, "ACTIVE_FILE", cfg / ".active_env")
+    monkeypatch.setattr(config, "CONFIG_FILE", cfg_file)
+    (cfg / ".active_env").write_text("aws-prod")
+    import chatops.providers.aws as aws_provider
+    monkeypatch.setattr(aws_provider, "is_authenticated", lambda env: True)
+    result = runner.invoke(app, ["env", "status"], env={"HOME": str(home)})
+    assert "authenticated" in result.output


### PR DESCRIPTION
## Summary
- prompt for cloud provider credentials when activating an environment
- track authentication state in `auth_cache`
- add `env status` command
- include provider auth modules for AWS, Azure, GCP and Docker
- document `env status`
- test authentication handling in `env` commands

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856e9bcf7848323a0bbd38f65904ff6