### PR TITLE
Add contributor workflow docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+- Provide a short summary of your changes.
+
+## Checklist
+- [ ] Tests pass via `./test.sh`
+- [ ] Documentation updated if needed
+- [ ] I have added an entry to the changelog if required

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+This project adheres to the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). All participants are expected to uphold this standard. Be considerate, respectful and collaborative in all interactions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for guidelines on developing and submitting patches.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ errors encountered during loading.
 
 ### Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.
+
 1. Fork the repository and create a virtual environment.
 2. Install in editable mode with ``pip install -e .``.
 3. Run ``./test.sh`` before submitting a pull request.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to ChatOps
+
+Thank you for helping improve this project! This document describes the workflow for new contributors.
+
+## Getting Started
+
+1. Fork the repository on GitHub and clone your fork.
+2. Create a virtual environment and install dependencies in editable mode:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e .
+   ```
+3. Install any additional development tools you might need (e.g. `black` or `flake8`).
+
+## Branch Workflow
+
+- Work from the `main` branch and create a feature branch for your change:
+
+  ```bash
+  git checkout -b my-feature
+  ```
+- Keep your branch focused on a single set of related changes.
+- Format your code with `black` and follow PEP 8 conventions.
+- Write or update tests under `tests/` and make sure they pass with `./test.sh`.
+
+## Commit Messages
+
+- Use clear, present‑tense messages (e.g. "Add deploy command tests").
+- Reference GitHub issues when applicable, e.g. `Fixes #42`.
+- Squash small fixups locally before opening a pull request.
+
+## Pull Requests
+
+1. Push your branch to your fork and open a pull request against `main`.
+2. Verify that GitHub Actions runs succeed.
+3. Fill out the pull request template checklist.
+4. Be responsive to review feedback and update your branch as needed.
+
+## Opening Issues
+
+If you encounter a bug or have a feature request, open an issue describing:
+
+- A clear title and summary
+- Steps to reproduce or motivation for the feature
+- Expected versus actual behavior
+
+## Code of Conduct
+
+All contributors are expected to follow the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). Be respectful and inclusive in all interactions.
+
+---
+Happy hacking!


### PR DESCRIPTION
## Summary
- document contributor workflow in docs/CONTRIBUTING.md
- reference documentation from README
- add minimal CONTRIBUTING.md and CODE_OF_CONDUCT
- add pull request template for GitHub

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856f28dce0083239eb46bd94d0f9e65